### PR TITLE
Add generate-config CLI command

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,4 +112,12 @@ func generateExampleConfig(configName string) {
 	}
 
 	fmt.Printf("Generated example config file: %s\n", configName)
+
+	fmt.Printf("Below are addresses that can be used to connect to this bootstrap node\n")
+	fmt.Printf("Replace 127.0.0.1 or ::1 with the appropriate IP address. If you don't have IPv6 support, just skip it\n\n")
+
+	fmt.Printf("/ip4/127.0.0.1/tcp/6150/p2p/%s\n", conf.P2pNode.PeerID)
+	fmt.Printf("/ip4/127.0.0.1/udp/6150/quic-v1/p2p/%s\n", conf.P2pNode.PeerID)
+	fmt.Printf("/ip6/::1/tcp/7250/p2p/%s\n", conf.P2pNode.PeerID)
+	fmt.Printf("/ip6/::1/udp/7250/quic-v1/p2p/%s\n", conf.P2pNode.PeerID)
 }

--- a/main.go
+++ b/main.go
@@ -2,10 +2,21 @@ package main
 
 import (
 	"context"
+	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/anywherelan/awl/p2p"
+	ds "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/anywherelan/awl-bootstrap-node/config"
 )
 
 // @title Anywherelan bootstrap node API
@@ -18,6 +29,16 @@ import (
 //go:generate swag init --parseDependency
 //go:generate rm -f docs/docs.go docs/swagger.json
 func main() {
+	configName := flag.String("config-name", "config.yaml", "Config filepath")
+	generateConfig := flag.Bool("generate-config", false, "Enable generating config instead of starting the server")
+	flag.Parse()
+
+	// go run main.go -generate-config -config-name=config.yaml
+	if *generateConfig {
+		generateExampleConfig(*configName)
+		return
+	}
+
 	app := New()
 	logger := app.SetupLoggerAndConfig()
 	ctx, ctxCancel := context.WithCancel(context.Background())
@@ -47,4 +68,48 @@ func main() {
 
 	finishedCh <- struct{}{}
 	logger.Info("exited normally")
+}
+
+func generateExampleConfig(configName string) {
+	_, err := os.Stat(configName)
+	if os.IsNotExist(err) {
+		// ok
+	} else if err != nil {
+		fmt.Printf("Error reading config file: %s\n", err)
+		os.Exit(1)
+	} else {
+		fmt.Printf("Config file %s already exists, specify different name with flag -config-name=new-config.yaml\n", configName)
+		os.Exit(1)
+	}
+
+	// disable logs
+	_ = os.Setenv("QUIC_GO_DISABLE_RECEIVE_BUFFER_WARNING", "true")
+	log.SetupLogging(zapcore.NewNopCore(), func(name string) zapcore.Level {
+		return zapcore.FatalLevel
+	})
+
+	conf := config.NewExampleConfig()
+
+	peerstore, _ := pstoremem.NewPeerstore()
+	p2pSrv := p2p.NewP2p(context.Background())
+	host, err := p2pSrv.InitHost(p2p.HostConfig{
+		Peerstore:    peerstore,
+		DHTDatastore: dssync.MutexWrap(ds.NewMapDatastore()),
+	})
+	if err != nil {
+		fmt.Printf("Error initializing test host: %s\n", err)
+		os.Exit(1)
+	}
+
+	privKey := host.Peerstore().PrivKey(host.ID())
+	conf.SetIdentity(privKey, host.ID())
+	_ = p2pSrv.Close()
+
+	err = config.SaveConfig(conf, configName)
+	if err != nil {
+		fmt.Printf("Error saving config file: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Generated example config file: %s\n", configName)
 }


### PR DESCRIPTION
On startup, add a validation check to ensure that the configuration is not empty. Do not save the configuration from a running server

For #4 